### PR TITLE
Add logging table and frontend log viewer

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,14 @@ require('dotenv').config({ path: __dirname + '/.env' });
 const express = require('express');
 const sql = require('mssql');
 
+async function log(message) {
+  try {
+    await sql.query`INSERT INTO logs(message, log_time) VALUES(${message}, GETDATE())`;
+  } catch (err) {
+    console.error('Logging failed', err);
+  }
+}
+
 const app = express();
 app.use(express.json());
 
@@ -27,9 +35,11 @@ app.post('/api/register', async (req, res) => {
   if (!device_id) return res.status(400).send('device_id required');
   try {
     await sql.query`INSERT INTO devices (id, registered_at) VALUES (${device_id}, GETDATE())`;
+    await log(`Registered device ${device_id}`);
     res.sendStatus(200);
   } catch (err) {
     console.error(err);
+    await log(`Error registering device ${device_id}: ${err.message}`);
     res.sendStatus(500);
   }
 });
@@ -42,10 +52,22 @@ app.post('/api/upload', async (req, res) => {
       INSERT INTO rci_data(timestamp, latitude, longitude, speed, direction, roughness, distance_m, device_id, ip_address, z_values, avg_speed, interval_s, algorithm_version)
       VALUES(${data.timestamp}, ${data.latitude}, ${data.longitude}, ${data.speed}, ${data.direction}, ${data.roughness}, ${data.distance_m}, ${data.device_id}, ${ip}, ${JSON.stringify(data.z_values)}, ${data.avg_speed}, ${data.interval_s}, ${data.algorithm_version})
     `;
+    await log(`Uploaded data from ${data.device_id}`);
     res.sendStatus(200);
   } catch (err) {
     console.error(err);
+    await log(`Error uploading data from ${data.device_id}: ${err.message}`);
     res.sendStatus(500);
+  }
+});
+
+app.get('/api/logs', async (req, res) => {
+  try {
+    const result = await sql.query`SELECT TOP (100) log_time, message FROM logs ORDER BY log_time DESC`;
+    res.json(result.recordset);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('error');
   }
 });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
         <button id="stopBtn" disabled>Stop meting</button>
     </div>
     <canvas id="chart" width="300" height="150"></canvas>
+    <div id="log" class="log"></div>
     <script src="main.js"></script>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -6,6 +6,7 @@ const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const chartCanvas = document.getElementById('chart');
 const ctx = chartCanvas.getContext('2d');
+const logDiv = document.getElementById('log');
 let chartData = [];
 
 let watchId;
@@ -172,3 +173,15 @@ function drawChart(value){
   });
   ctx.stroke();
 }
+
+function fetchLogs(){
+  fetch('/api/logs')
+    .then(r=>r.json())
+    .then(list=>{
+      logDiv.innerHTML = list.map(l=>`<div>${new Date(l.log_time).toLocaleString()} - ${l.message}</div>`).join('');
+      logDiv.scrollTop = logDiv.scrollHeight;
+    });
+}
+
+setInterval(fetchLogs, 5000);
+fetchLogs();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,3 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 #controls { margin-bottom: 10px; }
 canvas { border: 1px solid #ccc; }
+.log { margin-top: 10px; border: 1px solid #ccc; height: 150px; overflow-y: auto; font-size: 12px; padding: 5px; }


### PR DESCRIPTION
## Summary
- log actions and errors in `logs` table
- provide API to fetch logs
- show scrolling log on frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687917791de08320adf8d049ec39e6b9