### PR TITLE
Add maintenance page and clarify code sections

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,7 @@ const logger = require('./logger');
 const app = express();
 app.use(express.json());
 
+// ----- Startup Tasks -----
 // Request logging middleware - only log important API calls
 app.use(async (req, res, next) => {
   // Only log non-GET API requests to reduce spam (GET /api/logs is very frequent)
@@ -18,7 +19,8 @@ app.use(async (req, res, next) => {
 // Serve static frontend files
 require('./serve-frontend')(app);
 
-
+// ----- Startup Tasks -----
+// Database configuration and connection settings
 const config = {
   user: process.env.AZURE_SQL_USERNAME,
   password: process.env.AZURE_SQL_PASSWORD,
@@ -42,6 +44,7 @@ const ensureTables = require('./ensure-tables');
 
 let connectionPool = null;
 
+// Connect to the database and prepare tables
 sql.connect(config)
   .then(async (pool) => {
     connectionPool = pool;
@@ -119,6 +122,7 @@ app.post('/api/register', async (req, res) => {
   }
 });
 
+// ----- Data Storage and Retrieval -----
 app.post('/api/upload', async (req, res) => {
   const data = req.body;
   const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
@@ -258,6 +262,7 @@ app.use(async (err, req, res, next) => {
 });
 
 const port = process.env.PORT || 3000;
+// Start listening for requests
 const server = app.listen(port, () => {
   console.log(`[${new Date().toISOString()}] [INFO] [SERVER] Server started and listening on port ${port}`);
   // Don't try to log to database immediately as it might not be ready yet

--- a/backend/serve-frontend.js
+++ b/backend/serve-frontend.js
@@ -4,10 +4,15 @@ const logger = require('./logger');
 
 module.exports = function setupFrontend(app) {
   const frontendPath = path.join(__dirname, 'frontend');
-  
+
   // Custom static file serving with logging for index.html requests
   app.use(express.static(frontendPath));
-  
+
+  // Serve maintenance page separately so it doesn't fall under SPA routing
+  app.get('/maintenance', async (req, res) => {
+    res.sendFile(path.join(frontendPath, 'maintenance.html'));
+  });
+
   // For SPA: serve index.html for any non-API route
   app.get(/^\/(?!api).*/, async (req, res) => {
     // Don't log every frontend page request to reduce spam
@@ -16,3 +21,4 @@ module.exports = function setupFrontend(app) {
     res.sendFile(path.join(frontendPath, 'index.html'));
   });
 };
+

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,3 +1,5 @@
+
+// ----- Startup Tasks -----
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('service-worker.js');
 }
@@ -112,6 +114,7 @@ const algorithmVersion = '1.0';
 
 const deviceId = getDeviceId();
 
+// Startup initialization
 openDb();
 checkLocationStatus();
 
@@ -143,6 +146,7 @@ function getDeviceId() {
   return id;
 }
 
+// ----- Data Storage and Retrieval -----
 function openDb() {
   const request = indexedDB.open('rci', 1);
   request.onupgradeneeded = function(e) {
@@ -245,6 +249,7 @@ function onMotion(e) {
   drawChart(z);
 }
 
+// ----- Roughness Calculation -----
 function processWindow() {
   const values = sampleBuffer.map(s => s.z);
   const rms = Math.sqrt(values.reduce((s,v) => s+v*v,0)/values.length);

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maintenance</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Maintenance Overview</h1>
+  <h2>Server Endpoints</h2>
+  <ul>
+    <li><code>GET /api/device/:id</code> - Retrieve nickname for a device</li>
+    <li><code>POST /api/register</code> - Register or update a device nickname</li>
+    <li><code>POST /api/upload</code> - Upload measurement data</li>
+    <li><code>GET /api/logs</code> - Retrieve application logs</li>
+    <li><code>GET /api/logs/stats</code> - Summary statistics of logs</li>
+    <li><code>POST /api/logs</code> - Receive frontend log messages</li>
+    <li><code>GET /api/rci-data</code> - Retrieve measurement records for the map</li>
+  </ul>
+
+  <h2>Main Functions</h2>
+  <ul>
+    <li><strong>Backend</strong>
+      <ul>
+        <li><code>cleanupOldLogs()</code> - Remove old log entries from the database</li>
+      </ul>
+    </li>
+    <li><strong>Frontend</strong>
+      <ul>
+        <li><code>getDeviceId()</code> - Retrieve or generate the unique device ID</li>
+        <li><code>openDb()</code> - Open the local IndexedDB storage</li>
+        <li><code>startRecording()</code> - Begin data collection</li>
+        <li><code>stopRecording()</code> - Stop data collection</li>
+        <li><code>processWindow()</code> - Calculate roughness metrics from samples</li>
+        <li><code>saveRecord()</code> - Save measurements locally</li>
+        <li><code>uploadRecord()</code> - Send measurements to the backend</li>
+        <li><code>fetchLogs()</code> - Retrieve logs for display</li>
+      </ul>
+    </li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix `serve-frontend.js` and add new maintenance route
- mark startup, roughness, and data storage sections in code
- add Maintenance page listing endpoints and functions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a55c10bc4832083045d7cbd94278e