### PR TITLE
Fix log fetch error

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -344,7 +344,13 @@ function drawChart(value){
 
 function fetchLogs(){
   fetch('/api/logs')
-    .then(r=>r.json())
+    .then(async r => {
+      if (!r.ok) {
+        const text = await r.text();
+        throw new Error(`Server responded ${r.status}: ${text}`);
+      }
+      return r.json();
+    })
     .then(list=>{
       // Add new log lines to the bottom
       logDiv.innerHTML = list.map(l => {


### PR DESCRIPTION
## Summary
- add HTTP status check before parsing API responses in frontend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a69e38cdc8320b3ee32609b15aeb7