### PR TITLE
Add common header, language switcher and log view

### DIFF
--- a/frontend/device.html
+++ b/frontend/device.html
@@ -10,12 +10,25 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j8B+CHD+tN7J++nFSYYp0f5OIyyLTMnYhZi3kX0=" crossorigin=""></script>
 </head>
 <body>
+    <div class="top-bar">
+        <nav class="nav-bar">
+            <a href="index.html" data-i18n="navHome"></a>
+            <a href="device.html" data-i18n="navMap"></a>
+            <a href="maintenance.html" data-i18n="navMaintenance"></a>
+        </nav>
+        <div class="lang-switch">
+            <button data-lang="en">EN</button>
+            <button data-lang="nl">NL</button>
+        </div>
+    </div>
     <h1 data-i18n="mapTitle"></h1>
     <label for="nicknameInput" data-i18n="deviceNickname"></label>
     <input id="nicknameInput" type="text" />
     <button id="saveNicknameBtn" data-i18n="saveNickname"></button>
     <div id="map" style="height:400px;"></div>
+    <div id="log" class="log"></div>
     <script src="i18n.js"></script>
+    <script src="logs.js"></script>
     <script src="device.js"></script>
 </body>
 </html>

--- a/frontend/i18n.js
+++ b/frontend/i18n.js
@@ -1,8 +1,10 @@
 let translations = {};
+let currentLang = 'nl';
 
-function loadTranslations() {
-  const lang = (navigator.language || 'nl').slice(0,2).toLowerCase();
-  const file = `lang/${lang}.json`;
+function loadTranslations(lang) {
+  const selected = lang || localStorage.getItem('lang') || (navigator.language || 'nl').slice(0,2).toLowerCase();
+  currentLang = selected;
+  const file = `lang/${selected}.json`;
   return fetch(file)
     .then(r => r.ok ? r.json() : fetch('lang/en.json').then(rr => rr.json()))
     .then(data => {
@@ -35,7 +37,17 @@ function applyTranslations() {
   }
 }
 
+function setLanguage(lang) {
+  localStorage.setItem('lang', lang);
+  loadTranslations(lang);
+}
+
 // Load on startup
 if (typeof window !== 'undefined') {
   loadTranslations();
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.lang-switch button').forEach(btn => {
+      btn.addEventListener('click', () => setLanguage(btn.getAttribute('data-lang')));
+    });
+  });
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,17 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <div class="top-bar">
+        <nav class="nav-bar">
+            <a href="index.html" data-i18n="navHome"></a>
+            <a href="device.html" data-i18n="navMap"></a>
+            <a href="maintenance.html" data-i18n="navMaintenance"></a>
+        </nav>
+        <div class="lang-switch">
+            <button data-lang="en">EN</button>
+            <button data-lang="nl">NL</button>
+        </div>
+    </div>
     <h1 data-i18n="heading"></h1>
     <p data-i18n="roughnessIndex" style="font-size:14px;"></p>
     <div id="status-indicators" style="margin-bottom:10px;">
@@ -22,6 +33,7 @@
     <canvas id="chart" width="300" height="150"></canvas>
     <div id="log" class="log"></div>
     <script src="i18n.js"></script>
+    <script src="logs.js"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/frontend/lang/en.json
+++ b/frontend/lang/en.json
@@ -13,5 +13,8 @@
   "roughnessIndex": "RIBS – Roughness Index for Bicycle Surfaces",
   "roughnessLabel": "roughness",
   "deviceNickname": "Device nickname:",
-  "saveNickname": "Save"
+  "saveNickname": "Save",
+  "navHome": "Home",
+  "navMap": "Map",
+  "navMaintenance": "Maintenance"
 }

--- a/frontend/lang/nl.json
+++ b/frontend/lang/nl.json
@@ -13,5 +13,8 @@
   "roughnessIndex": "RIBS – Roughness Index for Bicycle Surfaces",
   "roughnessLabel": "ruwheid",
   "deviceNickname": "Apparaatnaam:",
-  "saveNickname": "Opslaan"
+  "saveNickname": "Opslaan",
+  "navHome": "Start",
+  "navMap": "Kaart",
+  "navMaintenance": "Onderhoud"
 }

--- a/frontend/logs.js
+++ b/frontend/logs.js
@@ -1,0 +1,32 @@
+function fetchLogs(){
+  const logDiv = document.getElementById('log');
+  if(!logDiv) return;
+  fetch('/api/logs')
+    .then(r => r.json())
+    .then(list => {
+      logDiv.innerHTML = list.map(l => {
+        const time = new Date(l.log_time).toLocaleString();
+        const levelClass = l.level ? l.level.toLowerCase() : 'info';
+        const source = l.source ? `[${l.source}]` : '';
+        return `<div class="log-entry log-${levelClass}">`+
+          `<span class="log-time">${time}</span>`+
+          `<span class="log-source">${source}</span>`+
+          `<span class="log-level">[${l.level || 'INFO'}]</span>`+
+          `<span class="log-message">${l.message}</span>`+
+          `</div>`;
+      }).join('');
+      logDiv.scrollTop = logDiv.scrollHeight;
+    })
+    .catch(err => {
+      if (typeof frontendLog === 'function') {
+        frontendLog(`Failed to fetch logs: ${err.message}`, 'ERROR', 'LOG_FETCH');
+      } else {
+        console.error('Failed to fetch logs', err);
+      }
+    });
+}
+
+if (typeof window !== 'undefined') {
+  setInterval(fetchLogs, 5000);
+  fetchLogs();
+}

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -7,6 +7,17 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div class="top-bar">
+    <nav class="nav-bar">
+      <a href="index.html" data-i18n="navHome"></a>
+      <a href="device.html" data-i18n="navMap"></a>
+      <a href="maintenance.html" data-i18n="navMaintenance"></a>
+    </nav>
+    <div class="lang-switch">
+      <button data-lang="en">EN</button>
+      <button data-lang="nl">NL</button>
+    </div>
+  </div>
   <h1>Maintenance Overview</h1>
   <h2>Server Endpoints</h2>
   <ul>
@@ -39,5 +50,8 @@
       </ul>
     </li>
   </ul>
+  <div id="log" class="log"></div>
+  <script src="i18n.js"></script>
+  <script src="logs.js"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -51,3 +51,21 @@ canvas { border: 1px solid #ccc; }
   margin-right: 2px;
   transition: color 0.2s;
 }
+
+/* Layout */
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.nav-bar a {
+  margin-right: 10px;
+  text-decoration: none;
+  color: #1a0dab;
+}
+
+.lang-switch button {
+  margin-left: 5px;
+}


### PR DESCRIPTION
## Summary
- add navigation bar and language switch to all pages
- add shared log viewer script
- support changing language at runtime
- style the new layout elements

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a69d826dc832095b71e56ae3791f1