### PR TITLE
Fix static file path for Azure deployment

### DIFF
--- a/backend/serve-frontend.js
+++ b/backend/serve-frontend.js
@@ -1,9 +1,13 @@
+const fs = require('fs');
 const path = require('path');
 const express = require('express');
 const logger = require('./logger');
 
 module.exports = function setupFrontend(app) {
-  const frontendPath = path.join(__dirname, '..', 'frontend');
+  let frontendPath = path.join(__dirname, '..', 'frontend');
+  if (!fs.existsSync(path.join(frontendPath, 'index.html'))) {
+    frontendPath = path.join(__dirname, 'frontend');
+  }
 
   // Custom static file serving with logging for index.html requests
   app.use(express.static(frontendPath));


### PR DESCRIPTION
## Summary
- detect whether frontend folder is embedded at runtime
- fall back to sibling folder if the default path does not contain `index.html`

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687aa4155d1083209b641ab9ae9ed938