### PR TITLE
Improve status indicator layout and logging

### DIFF
--- a/frontend/device.html
+++ b/frontend/device.html
@@ -25,18 +25,16 @@
     <div id="status-indicators" style="margin-bottom:8px; font-size:12px;">
       <table class="status-table" style="border-collapse:collapse;">
         <tr>
-          <td data-i18n="dbStatusLabel"></td>
-          <td><span id="dbStatus" class="status-dot" title="Database status">●</span></td>
-          <td data-i18n="logWriteStatusLabel"></td>
-          <td><span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
-          <td data-i18n="logFetchStatusLabel"></td>
-          <td><span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
-          <td data-i18n="dataWriteStatusLabel"></td>
-          <td><span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
-          <td data-i18n="dataFetchStatusLabel"></td>
-          <td><span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
-          <td data-i18n="testStatusLabel"></td>
-          <td><span id="testStatus" class="status-dot" title="Test status">●</span></td>
+          <td><span data-i18n="dbStatusLabel"></span> <span id="dbStatus" class="status-dot" title="Database status">●</span></td>
+          <td><span data-i18n="logWriteStatusLabel"></span> <span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
+          <td><span data-i18n="logFetchStatusLabel"></span> <span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
+          <td><span data-i18n="dataWriteStatusLabel"></span> <span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
+        </tr>
+        <tr>
+          <td><span data-i18n="dataFetchStatusLabel"></span> <span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
+          <td><span data-i18n="testStatusLabel"></span> <span id="testStatus" class="status-dot" title="Test status">●</span></td>
+          <td></td>
+          <td></td>
         </tr>
       </table>
     </div>
@@ -100,6 +98,18 @@
       <div class="legend-item"><div class="legend-color" style="background-color: hsl(80,100%,50%);"></div>Medium (2-5)</div>
       <div class="legend-item"><div class="legend-color" style="background-color: hsl(40,100%,50%);"></div>High (5-8)</div>
       <div class="legend-item"><div class="legend-color" style="background-color: hsl(0,100%,50%);"></div>Very High (8+)</div>
+    </div>
+    <div class="log-filters">
+      <label for="logLevelFilter">Level:</label>
+      <select id="logLevelFilter">
+        <option value="">All</option>
+        <option value="INFO">INFO</option>
+        <option value="WARN">WARN</option>
+        <option value="ERROR">ERROR</option>
+        <option value="DEBUG">DEBUG</option>
+      </select>
+      <label for="logSourceFilter">Source:</label>
+      <input id="logSourceFilter" type="text" placeholder="Source" />
     </div>
     <div id="log" class="log"></div>
     <script src="i18n.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,20 +24,16 @@
     <div id="status-indicators" style="margin-bottom:10px;">
       <table class="status-table" style="border-collapse:collapse;">
         <tr>
-          <td data-i18n="locationStatusLabel"></td>
-          <td><span id="locationStatus" class="status-dot" title="Location status">●</span></td>
-          <td data-i18n="dbStatusLabel"></td>
-          <td><span id="dbStatus" class="status-dot" title="Database status">●</span></td>
-          <td data-i18n="logWriteStatusLabel"></td>
-          <td><span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
-          <td data-i18n="logFetchStatusLabel"></td>
-          <td><span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
-          <td data-i18n="dataWriteStatusLabel"></td>
-          <td><span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
-          <td data-i18n="dataFetchStatusLabel"></td>
-          <td><span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
-          <td data-i18n="testStatusLabel"></td>
-          <td><span id="testStatus" class="status-dot" title="Test status">●</span></td>
+          <td><span data-i18n="locationStatusLabel"></span> <span id="locationStatus" class="status-dot" title="Location status">●</span></td>
+          <td><span data-i18n="dbStatusLabel"></span> <span id="dbStatus" class="status-dot" title="Database status">●</span></td>
+          <td><span data-i18n="logWriteStatusLabel"></span> <span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
+          <td><span data-i18n="logFetchStatusLabel"></span> <span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
+        </tr>
+        <tr>
+          <td><span data-i18n="dataWriteStatusLabel"></span> <span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
+          <td><span data-i18n="dataFetchStatusLabel"></span> <span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
+          <td><span data-i18n="testStatusLabel"></span> <span id="testStatus" class="status-dot" title="Test status">●</span></td>
+          <td></td>
         </tr>
       </table>
     </div>
@@ -45,6 +41,18 @@
         <button id="recordBtn" data-i18n="startButton"></button>
     </div>
     <canvas id="chart" width="300" height="150"></canvas>
+    <div class="log-filters">
+      <label for="logLevelFilter">Level:</label>
+      <select id="logLevelFilter">
+        <option value="">All</option>
+        <option value="INFO">INFO</option>
+        <option value="WARN">WARN</option>
+        <option value="ERROR">ERROR</option>
+        <option value="DEBUG">DEBUG</option>
+      </select>
+      <label for="logSourceFilter">Source:</label>
+      <input id="logSourceFilter" type="text" placeholder="Source" />
+    </div>
     <div id="log" class="log"></div>
     <script src="i18n.js"></script>
     <script src="logs.js"></script>

--- a/frontend/logs.js
+++ b/frontend/logs.js
@@ -1,7 +1,14 @@
+let currentLevelFilter = '';
+let currentSourceFilter = '';
+
 function fetchLogs(){
   const logDiv = document.getElementById('log');
   if(!logDiv) return;
-  fetch('/api/logs')
+  const params = new URLSearchParams();
+  if(currentLevelFilter) params.append('level', currentLevelFilter);
+  if(currentSourceFilter) params.append('source', currentSourceFilter);
+  const query = params.toString() ? `?${params.toString()}` : '';
+  fetch('/api/logs' + query)
     .then(r => r.json())
     .then(list => {
       logDiv.innerHTML = list.map(l => {
@@ -37,6 +44,24 @@ function fetchLogs(){
 }
 
 if (typeof window !== 'undefined') {
-  setInterval(fetchLogs, 5000);
-  fetchLogs();
+  document.addEventListener('DOMContentLoaded', () => {
+    const levelSelect = document.getElementById('logLevelFilter');
+    const sourceInput = document.getElementById('logSourceFilter');
+    if(levelSelect){
+      currentLevelFilter = levelSelect.value;
+      levelSelect.addEventListener('change', () => {
+        currentLevelFilter = levelSelect.value;
+        fetchLogs();
+      });
+    }
+    if(sourceInput){
+      currentSourceFilter = sourceInput.value;
+      sourceInput.addEventListener('input', () => {
+        currentSourceFilter = sourceInput.value;
+        fetchLogs();
+      });
+    }
+    fetchLogs();
+    setInterval(fetchLogs, 5000);
+  });
 }

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -440,16 +440,20 @@ async function runStartupTests() {
   ];
   
   const results = await Promise.allSettled(tests.map(test => test()));
-  
+
   const failed = results.filter(r => r.status === 'rejected');
   const passed = results.filter(r => r.status === 'fulfilled');
-  
+
   if (failed.length === 0) {
     setTestStatus(true);
     frontendLog(`All startup tests passed (${passed.length}/${results.length})`, 'INFO', 'STARTUP_TESTS');
   } else {
     const errors = failed.map(r => r.reason?.message || r.reason).join(', ');
     setTestStatus(false, errors);
+    failed.forEach((r, idx) => {
+      const name = tests[idx].name || `test${idx}`;
+      frontendLog(`Test ${name} failed: ${r.reason?.message || r.reason}`, 'DEBUG', 'STARTUP_TESTS');
+    });
     frontendLog(`Startup tests failed: ${failed.length}/${results.length} - ${errors}`, 'ERROR', 'STARTUP_TESTS');
   }
 }

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -22,18 +22,16 @@
   <div id="status-indicators" style="margin-bottom:10px;">
     <table class="status-table" style="border-collapse:collapse;">
       <tr>
-        <td data-i18n="dbStatusLabel"></td>
-        <td><span id="dbStatus" class="status-dot" title="Database status">●</span></td>
-        <td data-i18n="logWriteStatusLabel"></td>
-        <td><span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
-        <td data-i18n="logFetchStatusLabel"></td>
-        <td><span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
-        <td data-i18n="dataWriteStatusLabel"></td>
-        <td><span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
-        <td data-i18n="dataFetchStatusLabel"></td>
-        <td><span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
-        <td data-i18n="testStatusLabel"></td>
-        <td><span id="testStatus" class="status-dot" title="Test status">●</span></td>
+        <td><span data-i18n="dbStatusLabel"></span> <span id="dbStatus" class="status-dot" title="Database status">●</span></td>
+        <td><span data-i18n="logWriteStatusLabel"></span> <span id="logWriteStatus" class="status-dot" title="Log writing status">●</span></td>
+        <td><span data-i18n="logFetchStatusLabel"></span> <span id="logFetchStatus" class="status-dot" title="Log fetching status">●</span></td>
+        <td><span data-i18n="dataWriteStatusLabel"></span> <span id="dataWriteStatus" class="status-dot" title="Data writing status">●</span></td>
+      </tr>
+      <tr>
+        <td><span data-i18n="dataFetchStatusLabel"></span> <span id="dataFetchStatus" class="status-dot" title="Data fetching status">●</span></td>
+        <td><span data-i18n="testStatusLabel"></span> <span id="testStatus" class="status-dot" title="Test status">●</span></td>
+        <td></td>
+        <td></td>
       </tr>
     </table>
   </div>
@@ -74,6 +72,18 @@
       </ul>
     </li>
   </ul>
+  <div class="log-filters">
+    <label for="logLevelFilter">Level:</label>
+    <select id="logLevelFilter">
+      <option value="">All</option>
+      <option value="INFO">INFO</option>
+      <option value="WARN">WARN</option>
+      <option value="ERROR">ERROR</option>
+      <option value="DEBUG">DEBUG</option>
+    </select>
+    <label for="logSourceFilter">Source:</label>
+    <input id="logSourceFilter" type="text" placeholder="Source" />
+  </div>
   <div id="log" class="log"></div>
   <script src="i18n.js"></script>
   <script src="logs.js"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5,6 +5,18 @@
   font-size: 12px;
   border: none;
 }
+.log-filters {
+  margin-top: 5px;
+  font-size: 12px;
+}
+.log-filters label {
+  margin-right: 2px;
+}
+.log-filters select,
+.log-filters input {
+  font-size: 12px;
+  margin-right: 4px;
+}
 body { font-family: Arial, sans-serif; margin: 20px; }
 #controls { margin-bottom: 10px; }
 canvas { border: 1px solid #ccc; }

--- a/frontend/test-indicators.html
+++ b/frontend/test-indicators.html
@@ -15,20 +15,20 @@
     
     <div class="test-section">
         <h2>Current Status</h2>
-        <div>
-            <span>Database:</span>
-            <span id="dbStatus" class="status-dot">●</span>
-            <span>Log Write:</span>
-            <span id="logWriteStatus" class="status-dot">●</span>
-            <span>Log Fetch:</span>
-            <span id="logFetchStatus" class="status-dot">●</span>
-            <span>Data Write:</span>
-            <span id="dataWriteStatus" class="status-dot">●</span>
-            <span>Data Fetch:</span>
-            <span id="dataFetchStatus" class="status-dot">●</span>
-            <span>Tests:</span>
-            <span id="testStatus" class="status-dot">●</span>
-        </div>
+        <table class="status-table" style="border-collapse:collapse;">
+            <tr>
+                <td>Database: <span id="dbStatus" class="status-dot">●</span></td>
+                <td>Log Write: <span id="logWriteStatus" class="status-dot">●</span></td>
+                <td>Log Fetch: <span id="logFetchStatus" class="status-dot">●</span></td>
+                <td>Data Write: <span id="dataWriteStatus" class="status-dot">●</span></td>
+            </tr>
+            <tr>
+                <td>Data Fetch: <span id="dataFetchStatus" class="status-dot">●</span></td>
+                <td>Tests: <span id="testStatus" class="status-dot">●</span></td>
+                <td></td>
+                <td></td>
+            </tr>
+        </table>
     </div>
 
     <div class="test-section">
@@ -234,7 +234,7 @@
         async function runAllTests() {
             log('=== Running all tests ===');
             const tests = [testLogWrite, testLogFetch, testDataWrite, testDataFetch];
-            
+
             const results = await Promise.allSettled(tests.map(test => test()));
             
             const failed = results.filter(r => r.status === 'rejected');
@@ -246,6 +246,16 @@
             } else {
                 const errors = failed.map(r => r.reason?.message || r.reason).join(', ');
                 setTestStatus(false, `${failed.length} failed`);
+                failed.forEach((r, idx) => {
+                    const name = tests[idx].name || `test${idx}`;
+                    const msg = `Test ${name} failed: ${r.reason?.message || r.reason}`;
+                    log(msg);
+                    fetch('/api/logs', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({ message: msg, level: 'DEBUG', source: 'TEST_PAGE' })
+                    }).catch(() => {});
+                });
                 log(`=== TESTS FAILED: ${failed.length}/${results.length} - ${errors} ===`);
             }
         }

--- a/test-indicators.html
+++ b/test-indicators.html
@@ -15,20 +15,20 @@
     
     <div class="test-section">
         <h2>Current Status</h2>
-        <div>
-            <span>Database:</span>
-            <span id="dbStatus" class="status-dot">●</span>
-            <span>Log Write:</span>
-            <span id="logWriteStatus" class="status-dot">●</span>
-            <span>Log Fetch:</span>
-            <span id="logFetchStatus" class="status-dot">●</span>
-            <span>Data Write:</span>
-            <span id="dataWriteStatus" class="status-dot">●</span>
-            <span>Data Fetch:</span>
-            <span id="dataFetchStatus" class="status-dot">●</span>
-            <span>Tests:</span>
-            <span id="testStatus" class="status-dot">●</span>
-        </div>
+        <table class="status-table" style="border-collapse:collapse;">
+            <tr>
+                <td>Database: <span id="dbStatus" class="status-dot">●</span></td>
+                <td>Log Write: <span id="logWriteStatus" class="status-dot">●</span></td>
+                <td>Log Fetch: <span id="logFetchStatus" class="status-dot">●</span></td>
+                <td>Data Write: <span id="dataWriteStatus" class="status-dot">●</span></td>
+            </tr>
+            <tr>
+                <td>Data Fetch: <span id="dataFetchStatus" class="status-dot">●</span></td>
+                <td>Tests: <span id="testStatus" class="status-dot">●</span></td>
+                <td></td>
+                <td></td>
+            </tr>
+        </table>
     </div>
 
     <div class="test-section">
@@ -234,7 +234,7 @@
         async function runAllTests() {
             log('=== Running all tests ===');
             const tests = [testLogWrite, testLogFetch, testDataWrite, testDataFetch];
-            
+
             const results = await Promise.allSettled(tests.map(test => test()));
             
             const failed = results.filter(r => r.status === 'rejected');
@@ -246,6 +246,16 @@
             } else {
                 const errors = failed.map(r => r.reason?.message || r.reason).join(', ');
                 setTestStatus(false, `${failed.length} failed`);
+                failed.forEach((r, idx) => {
+                    const name = tests[idx].name || `test${idx}`;
+                    const msg = `Test ${name} failed: ${r.reason?.message || r.reason}`;
+                    log(msg);
+                    fetch('/api/logs', {
+                        method: 'POST',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({ message: msg, level: 'DEBUG', source: 'TEST_PAGE' })
+                    }).catch(() => {});
+                });
                 log(`=== TESTS FAILED: ${failed.length}/${results.length} - ${errors} ===`);
             }
         }


### PR DESCRIPTION
## Summary
- arrange UI status indicators in a 2x4 table
- add log level and source filters for the log output
- output detailed debug info when tests fail

## Testing
- `npm --prefix backend test` *(fails: Error: no test specified)*
- `node backend/test-schema.js`

------
https://chatgpt.com/codex/tasks/task_e_687b4d6c7c9c8320b2caadb7b0de6e2d