### PR TITLE
Add clear logs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Het systeem bevat een uitgebreid logging mechanisme:
 - `GET /api/logs` - Haal logs op (met filtering op level, source, limit)
 - `POST /api/logs` - Verstuur frontend logs naar database
 - `GET /api/logs/stats` - Krijg statistieken over logs
+- `DELETE /api/logs` - Verwijder alle logregels
 
 ### Database Schema
 

--- a/backend/database.js
+++ b/backend/database.js
@@ -520,11 +520,22 @@ async function cleanupOldLogs() {
   }
 
   await executeQuery(`
-    DELETE FROM logs 
+    DELETE FROM logs
     WHERE id NOT IN (
       SELECT TOP 1000 id FROM logs ORDER BY log_time DESC
     )
   `);
+}
+
+/**
+ * Remove all log entries
+ */
+async function clearLogs() {
+  if (!isDatabaseReady()) {
+    throw new Error('Database not ready');
+  }
+
+  await executeQuery('DELETE FROM logs');
 }
 
 // ===== DEVICE OPERATIONS =====
@@ -722,6 +733,7 @@ module.exports = {
   getLogs,
   getLogStats,
   cleanupOldLogs,
+  clearLogs,
   
   // Device operations
   getDevice,

--- a/backend/index.js
+++ b/backend/index.js
@@ -196,6 +196,25 @@ app.post('/api/logs', async (req, res) => {
     await logger.error(`Error logging frontend message from IP ${ip}: ${err.message}`, 'API');
     res.status(500).json({ error: 'Failed to log message' });
   }
+  });
+
+// Endpoint to clear all logs
+app.delete('/api/logs', async (req, res) => {
+  const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+
+  if (!database.isDatabaseReady()) {
+    await logger.warn('Database not ready, cannot clear logs', 'API');
+    return res.status(503).send('Database not ready');
+  }
+
+  try {
+    await database.clearLogs();
+    await logger.api('Logs cleared', `IP: ${ip}`);
+    res.sendStatus(200);
+  } catch (err) {
+    await logger.error(`Error clearing logs for IP ${ip}: ${err.message}`, 'API');
+    res.status(500).send('error');
+  }
 });
 
 // Endpoint to retrieve measurement records for map view

--- a/frontend/logs.js
+++ b/frontend/logs.js
@@ -43,10 +43,31 @@ function fetchLogs(){
     });
 }
 
+function clearLogs() {
+  if (!confirm('Clear all logs?')) return;
+  fetch('/api/logs', { method: 'DELETE' })
+    .then(res => {
+      if (res.ok) {
+        fetchLogs();
+        if (typeof frontendLog === 'function') {
+          frontendLog('Logs cleared', 'INFO', 'MAINTENANCE');
+        }
+      } else if (typeof frontendLog === 'function') {
+        frontendLog(`Failed to clear logs: HTTP ${res.status}`, 'ERROR', 'MAINTENANCE');
+      }
+    })
+    .catch(err => {
+      if (typeof frontendLog === 'function') {
+        frontendLog(`Failed to clear logs: ${err.message}`, 'ERROR', 'MAINTENANCE');
+      }
+    });
+}
+
 if (typeof window !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
     const levelSelect = document.getElementById('logLevelFilter');
     const sourceInput = document.getElementById('logSourceFilter');
+    const clearBtn = document.getElementById('clearLogsBtn');
     if(levelSelect){
       currentLevelFilter = levelSelect.value;
       levelSelect.addEventListener('change', () => {
@@ -60,6 +81,9 @@ if (typeof window !== 'undefined') {
         currentSourceFilter = sourceInput.value;
         fetchLogs();
       });
+    }
+    if(clearBtn){
+      clearBtn.addEventListener('click', clearLogs);
     }
     fetchLogs();
     setInterval(fetchLogs, 5000);

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -83,6 +83,7 @@
     </select>
     <label for="logSourceFilter">Source:</label>
     <input id="logSourceFilter" type="text" placeholder="Source" />
+    <button id="clearLogsBtn">Clear Logs</button>
   </div>
   <div id="log" class="log"></div>
   <script src="i18n.js"></script>


### PR DESCRIPTION
## Summary
- allow deletion of logs via new `DELETE /api/logs` endpoint
- provide `clearLogs` method in the database module
- add Clear Logs button on the maintenance page and JS handler
- document the new endpoint

## Testing
- `npm install` in backend
- `node backend/test-schema.js`

------
https://chatgpt.com/codex/tasks/task_e_687b4f0f16888320a4710bc915175c7f