### PR TITLE
Add DB maintenance info and tests

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -237,6 +237,46 @@ app.get('/api/rci-data', async (req, res) => {
   }
 });
 
+// Endpoint to get database summaries
+app.get('/api/dbinfo', async (req, res) => {
+  try {
+    const info = await database.getDatabaseInfo();
+    res.json(info);
+  } catch (err) {
+    await logger.error(`Error retrieving database info: ${err.message}`, 'API');
+    res.status(500).json({ error: 'failed' });
+  }
+});
+
+// Endpoint to fetch latest records from a table
+app.get('/api/db/:table/latest', async (req, res) => {
+  const table = req.params.table;
+  const limit = parseInt(req.query.limit) || 10;
+  try {
+    const records = await database.getLatestRecords(table, limit);
+    res.json(records);
+  } catch (err) {
+    await logger.error(`Error retrieving latest from ${table}: ${err.message}`, 'API');
+    res.status(500).json({ error: 'failed' });
+  }
+});
+
+// Endpoint to run test on a table
+app.post('/api/db/:table/test', async (req, res) => {
+  const table = req.params.table;
+  try {
+    const result = await database.testTable(table);
+    if (result.success) {
+      res.json(result);
+    } else {
+      throw new Error(result.error);
+    }
+  } catch (err) {
+    await logger.error(`Table test for ${table} failed: ${err.message}`, 'API');
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Global error handling middleware
 app.use(async (err, req, res, next) => {
   const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -52,6 +52,15 @@
     <p>Loading schema information...</p>
   </div>
 
+  <h2>Database Info</h2>
+  <button id="refreshDbBtn">Refresh</button>
+  <table id="dbInfoTable" class="status-table" style="border-collapse:collapse;">
+    <thead>
+      <tr><th>Table</th><th>Records</th><th>Last Update</th><th colspan="2">Actions</th></tr>
+    </thead>
+    <tbody id="dbTableBody"></tbody>
+  </table>
+
   <h2>Main Functions</h2>
   <ul>
     <li><strong>Backend</strong>
@@ -89,6 +98,7 @@
   <script src="i18n.js"></script>
   <script src="logs.js"></script>
   <script src="main.js"></script>
+  <script src="maintenance.js"></script>
   <script>
     // Load schema status information
     async function loadSchemaStatus() {

--- a/frontend/maintenance.js
+++ b/frontend/maintenance.js
@@ -1,0 +1,43 @@
+export async function loadDbInfo() {
+  const tableBody = document.getElementById('dbTableBody');
+  if (!tableBody) return;
+  tableBody.innerHTML = '<tr><td colspan="5">Loading...</td></tr>';
+  try {
+    const res = await fetch('/api/dbinfo');
+    const data = await res.json();
+    tableBody.innerHTML = data
+      .map(
+        d => `<tr><td>${d.name}</td><td>${d.count}</td><td>${d.last_update ? new Date(d.last_update).toLocaleString() : '-'}</td>` +
+          `<td><button data-action="latest" data-table="${d.name}">Show</button></td>` +
+          `<td><button data-action="test" data-table="${d.name}">Test</button></td></tr>`
+      )
+      .join('');
+  } catch (err) {
+    tableBody.innerHTML = `<tr><td colspan="5">Error: ${err.message}</td></tr>`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const refreshBtn = document.getElementById('refreshDbBtn');
+  if (refreshBtn) refreshBtn.addEventListener('click', loadDbInfo);
+
+  const tableBody = document.getElementById('dbTableBody');
+  if (tableBody) {
+    tableBody.addEventListener('click', async e => {
+      const action = e.target.dataset.action;
+      const table = e.target.dataset.table;
+      if (!action || !table) return;
+      if (action === 'latest') {
+        const res = await fetch(`/api/db/${table}/latest?limit=10`);
+        const data = await res.json();
+        alert(JSON.stringify(data, null, 2));
+      } else if (action === 'test') {
+        const res = await fetch(`/api/db/${table}/test`, { method: 'POST' });
+        const result = await res.json();
+        alert(JSON.stringify(result, null, 2));
+      }
+    });
+  }
+
+  loadDbInfo();
+});

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5,6 +5,11 @@
   font-size: 12px;
   border: none;
 }
+.status-table th {
+  padding-right: 6px;
+  text-align: left;
+  font-size: 12px;
+}
 .log-filters {
   margin-top: 5px;
   font-size: 12px;


### PR DESCRIPTION
## Summary
- implement new `getDatabaseInfo`, `getLatestRecords`, and `testTable` helpers
- expose API endpoints for database info, record previews and table tests
- show database summaries on maintenance page with refresh, show and test buttons
- add small stylesheet tweaks and new `maintenance.js`

## Testing
- `npm install` in backend
- `node test-schema.js`

------
https://chatgpt.com/codex/tasks/task_e_687b6575a0308320aae2afa2e51480f2