### PR TITLE
Fix maintenance indicators and default filters

### DIFF
--- a/frontend/device.html
+++ b/frontend/device.html
@@ -102,7 +102,7 @@
     <div class="log-filters">
       <label for="logLevelFilter">Level:</label>
       <select id="logLevelFilter" multiple>
-        <option value="">All</option>
+        <option value="" selected>All</option>
         <option value="INFO">INFO</option>
         <option value="WARN">WARN</option>
         <option value="ERROR">ERROR</option>
@@ -110,7 +110,7 @@
       </select>
       <label for="logSourceFilter">Source:</label>
       <select id="logSourceFilter" multiple>
-        <option value="">All</option>
+        <option value="" selected>All</option>
         <option value="SERVER">SERVER</option>
         <option value="API">API</option>
         <option value="DATABASE">DATABASE</option>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -44,7 +44,7 @@
     <div class="log-filters">
       <label for="logLevelFilter">Level:</label>
       <select id="logLevelFilter" multiple>
-        <option value="">All</option>
+        <option value="" selected>All</option>
         <option value="INFO">INFO</option>
         <option value="WARN">WARN</option>
         <option value="ERROR">ERROR</option>
@@ -52,7 +52,7 @@
       </select>
       <label for="logSourceFilter">Source:</label>
       <select id="logSourceFilter" multiple>
-        <option value="">All</option>
+        <option value="" selected>All</option>
         <option value="SERVER">SERVER</option>
         <option value="API">API</option>
         <option value="DATABASE">DATABASE</option>

--- a/frontend/maintenance.html
+++ b/frontend/maintenance.html
@@ -84,7 +84,7 @@
   <div class="log-filters">
     <label for="logLevelFilter">Level:</label>
     <select id="logLevelFilter" multiple>
-      <option value="">All</option>
+      <option value="" selected>All</option>
       <option value="INFO">INFO</option>
       <option value="WARN">WARN</option>
       <option value="ERROR">ERROR</option>
@@ -92,7 +92,7 @@
     </select>
     <label for="logSourceFilter">Source:</label>
     <select id="logSourceFilter" multiple>
-      <option value="">All</option>
+      <option value="" selected>All</option>
       <option value="SERVER">SERVER</option>
       <option value="API">API</option>
       <option value="DATABASE">DATABASE</option>
@@ -112,7 +112,7 @@
   <div id="log" class="log"></div>
   <script src="i18n.js"></script>
   <script src="logs.js"></script>
-  <script src="main.js"></script>
+  <script src="status.js"></script>
   <script src="maintenance.js"></script>
   <script>
     // Load schema status information


### PR DESCRIPTION
## Summary
- default the log filters to `All`
- switch maintenance page to lightweight `status.js`

## Testing
- `npm test --prefix backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b79f242bc8320969274032629fbba